### PR TITLE
Handle missing Streamlit secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,13 @@ export VERTEXAI_CREDENTIALS=/path/to/your/service_account.json
 ```
 
 This keeps the credentials file outside the repository.
+
+Alternatively you can use a Streamlit secrets file.  Create
+`.streamlit/secrets.toml` at the project root with a line like:
+
+```toml
+VERTEXAI_CREDENTIALS = "/path/to/your/service_account.json"
+```
+
+When running `streamlit run app.py` the path (or the JSON content itself)
+will be read from this file if the environment variable is not set.

--- a/generative.py
+++ b/generative.py
@@ -31,15 +31,22 @@ GEMINI_PRO_MODEL = "gemini-2.5-pro-preview-03-25"
 def _configure_vertex_credentials():
     cred = os.getenv("VERTEXAI_CREDENTIALS")
     if not cred and hasattr(st, "secrets"):
-        cred = st.secrets.get("VERTEXAI_CREDENTIALS")
-    if cred:
-        if not os.path.isfile(cred) and cred.strip().startswith("{"):
-            import tempfile
-            tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".json")
-            tmp.write(cred.encode())
-            tmp.close()
-            cred = tmp.name
-        os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = cred
+        try:
+            cred = st.secrets["VERTEXAI_CREDENTIALS"]
+        except Exception:
+            cred = None
+    if not cred:
+        logging.warning(
+            "VERTEXAI_CREDENTIALS not provided; Vertex AI features may fail"
+        )
+        return
+    if not os.path.isfile(cred) and cred.strip().startswith("{"):
+        import tempfile
+        tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".json")
+        tmp.write(cred.encode())
+        tmp.close()
+        cred = tmp.name
+    os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = cred
 
 _configure_vertex_credentials()
 


### PR DESCRIPTION
## Summary
- handle missing secrets gracefully in `generative._configure_vertex_credentials`
- document using `.streamlit/secrets.toml`

## Testing
- `python -m py_compile $(git ls-files '*.py')`