### PR TITLE
Fix parse_row for CR assets

### DIFF
--- a/app.py
+++ b/app.py
@@ -148,7 +148,6 @@ def build_fullcode_ann(df: pd.DataFrame):
 
 def parse_row(code: str) -> dict:
     parts = [p.strip() for p in code.split(":")]
-    if parts[0].upper()=="CR": parts=parts[1:]
     a0 = parts[0].upper()
     if a0 in ("CDS","CR"): asset="CDS"
     elif a0=="BOND": asset="BOND"

--- a/data_io.py
+++ b/data_io.py
@@ -34,9 +34,6 @@ for cfg in ASSET_CONFIG.values():
 # ─── PARSING LOGIC ──────────────────────────────────────────────────────
 def parse_row(code: str) -> dict:
     parts = [p.strip() for p in code.split(":")]
-    # drop leading 'CR'
-    if parts and parts[0].upper()=="CR":
-        parts = parts[1:]
     a0 = parts[0].upper()
     if a0 in ("CDS","CR"):
         asset = "CDS"


### PR DESCRIPTION
## Summary
- handle `CR:` codes correctly in `parse_row`
- remove old logic that chopped off the `CR` token

## Testing
- `python -m pytest` *(fails: No module named pytest)*