### PR TITLE
Add CLI scenario pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,23 @@ VERTEXAI_CREDENTIALS = "/path/to/your/service_account.json"
 
 When running `streamlit run app.py` the path (or the JSON content itself)
 will be read from this file if the environment variable is not set.
+
+## Command-line pipeline
+
+The script `pipeline_flow.py` runs the full process:
+
+1. Load a portfolio CSV/Excel/JSON file.
+2. Parse a universe of risk factors.
+3. Automatically map portfolio tickers to risk-factor codes.
+4. Apply baseline shocks by asset class and severity.
+5. Output a scenario PnL CSV.
+
+Example:
+
+```bash
+python pipeline_flow.py --portfolio synthetic_portfolio.csv \
+                       --universe synthetic_universe.csv \
+                       --severity Medium --output pnl.csv
+```
+
+This will create `pnl.csv` with the shocked PnL per position.

--- a/pipeline_flow.py
+++ b/pipeline_flow.py
@@ -1,0 +1,55 @@
+import argparse
+import pandas as pd
+from portfolio import PortfolioIngestor, RiskFactorMapper
+from data_io import parse_df
+from exposures import apply_shocks
+from config import SHOCK_UNITS, BASELINE_SHOCKS
+
+
+def _baseline_shocks(rf_df: pd.DataFrame, severity: str) -> pd.DataFrame:
+    """Assign baseline shocks based on asset class and severity."""
+    values = []
+    for _, row in rf_df.iterrows():
+        unit = SHOCK_UNITS.get(row["asset"], "pct")
+        values.append(BASELINE_SHOCKS[unit][severity])
+    rf_df = rf_df.copy()
+    rf_df["shock_pct"] = values
+    return rf_df
+
+
+def run_pipeline(portfolio: str, universe: str, severity: str = "Medium") -> pd.DataFrame:
+    """Full portfolio → RF → scenario PnL flow."""
+    ing = PortfolioIngestor(portfolio)
+    pf = ing.get()
+
+    raw_univ = pd.read_csv(universe, header=None, names=["code"])
+    univ = parse_df(raw_univ)
+
+    mapper = RiskFactorMapper(univ)
+    mapped = mapper.map(pf)
+
+    rf_codes = mapped["rf_code"].dropna().unique()
+    rf_df = univ[univ["original"].isin(rf_codes)].copy()
+    rf_df = _baseline_shocks(rf_df, severity)
+
+    pnl_df = apply_shocks(mapped, rf_df)
+    return pnl_df
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description="End-to-end scenario pipeline")
+    p.add_argument("--portfolio", required=True, help="Path to portfolio file")
+    p.add_argument("--universe", required=True, help="Path to universe CSV")
+    p.add_argument(
+        "--severity", choices=["Low", "Medium", "High", "Extreme"], default="Medium"
+    )
+    p.add_argument("--output", default="scenario_pnl.csv", help="Output CSV path")
+    args = p.parse_args()
+
+    pnl = run_pipeline(args.portfolio, args.universe, args.severity)
+    pnl.to_csv(args.output, index=False)
+    print(f"Saved scenario PnL to {args.output} ({len(pnl)} rows)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `pipeline_flow.py` as a simple end-to-end command line pipeline
- document how to run the pipeline in the README

## Testing
- `python -m py_compile pipeline_flow.py`
- `python -m py_compile *.py`
- `python pipeline_flow.py --portfolio synthetic_portfolio.csv --universe synthetic_universe.csv --severity Medium --output test_pnl.csv` *(fails: ModuleNotFoundError: No module named 'pandas')*