### PR TITLE
Add asset-class pricing models

### DIFF
--- a/exposures.py
+++ b/exposures.py
@@ -1,5 +1,6 @@
 import pandas as pd
 from config import SHOCK_UNITS
+from pricing import get_pricing_function
 
 def apply_shocks(mapped_portfolio: pd.DataFrame, rf_df: pd.DataFrame) -> pd.DataFrame:
     """Merge portfolio with RF shocks and compute PnL for each position."""
@@ -12,10 +13,17 @@ def apply_shocks(mapped_portfolio: pd.DataFrame, rf_df: pd.DataFrame) -> pd.Data
     def _pnl(row):
         if pd.isna(row.get("shock_pct")):
             return 0.0
+        fn = get_pricing_function(row.get("asset"))
+        if fn:
+            return fn(row)
         unit = SHOCK_UNITS.get(row.get("asset"), "pct")
         pct = row["shock_pct"] / 10000 if unit == "bps" else row["shock_pct"] / 100
-        return -row["quantity"] * row["price"] * pct
+        return -row["quantity"] * row.get("price", 1.0) * pct
 
     pf["pnl"] = pf.apply(_pnl, axis=1)
     return pf
+
+def asset_pnl_breakdown(pnl_df: pd.DataFrame) -> pd.DataFrame:
+    """Return total PnL per asset class."""
+    return pnl_df.groupby("asset")["pnl"].sum().reset_index().rename(columns={"pnl": "asset_pnl"})
 

--- a/pipeline_flow.py
+++ b/pipeline_flow.py
@@ -2,7 +2,7 @@ import argparse
 import pandas as pd
 from portfolio import PortfolioIngestor, RiskFactorMapper
 from data_io import parse_df
-from exposures import apply_shocks
+from exposures import apply_shocks, asset_pnl_breakdown
 from config import SHOCK_UNITS, BASELINE_SHOCKS
 
 
@@ -33,7 +33,8 @@ def run_pipeline(portfolio: str, universe: str, severity: str = "Medium") -> pd.
     rf_df = _baseline_shocks(rf_df, severity)
 
     pnl_df = apply_shocks(mapped, rf_df)
-    return pnl_df
+    pnl_breakdown = asset_pnl_breakdown(pnl_df)
+    return pnl_df, pnl_breakdown
 
 
 def main() -> None:
@@ -46,9 +47,11 @@ def main() -> None:
     p.add_argument("--output", default="scenario_pnl.csv", help="Output CSV path")
     args = p.parse_args()
 
-    pnl = run_pipeline(args.portfolio, args.universe, args.severity)
+    pnl, breakdown = run_pipeline(args.portfolio, args.universe, args.severity)
     pnl.to_csv(args.output, index=False)
+    breakdown.to_csv("asset_pnl.csv", index=False)
     print(f"Saved scenario PnL to {args.output} ({len(pnl)} rows)")
+    print("Asset-class breakdown saved to asset_pnl.csv")
 
 
 if __name__ == "__main__":

--- a/pricing.py
+++ b/pricing.py
@@ -1,0 +1,61 @@
+import re
+import pandas as pd
+
+__all__ = [
+    "get_pricing_function",
+    "aggregate_asset_pnl",
+]
+
+def _tenor_to_years(s: str) -> float:
+    t = str(s or "").strip().upper()
+    if t == "ON":
+        return 1/12
+    m = re.match(r"^(\d+(?:\.\d+)?)([DWMY])$", t)
+    if not m:
+        return 0.0
+    val, unit = float(m.group(1)), m.group(2)
+    months = {"D":1/30, "W":7/30, "M":1, "Y":12}[unit] * val
+    return months / 12
+
+def _equity_pnl(row: pd.Series) -> float:
+    pct = row["shock_pct"] / 100
+    return -row["quantity"] * row["price"] * pct
+
+def _fx_pnl(row: pd.Series) -> float:
+    pct = row["shock_pct"] / 100
+    return -row["quantity"] * row.get("price", 1.0) * pct
+
+def _commodity_pnl(row: pd.Series) -> float:
+    pct = row["shock_pct"] / 100
+    return -row["quantity"] * row["price"] * pct
+
+def _bond_pnl(row: pd.Series) -> float:
+    bps = row["shock_pct"]
+    yrs = _tenor_to_years(row.get("tenor")) or 5.0
+    return -row["quantity"] * row["price"] * yrs * (bps / 10000)
+
+def _cds_pnl(row: pd.Series) -> float:
+    return _bond_pnl(row)
+
+def _ir_pnl(row: pd.Series) -> float:
+    bps = row["shock_pct"]
+    yrs = _tenor_to_years(row.get("tenor")) or 1.0
+    return -row["quantity"] * row["price"] * yrs * (bps / 10000)
+
+_PRICERS = {
+    "EQ": _equity_pnl,
+    "FXSPOT": _fx_pnl,
+    "CMD": _commodity_pnl,
+    "BOND": _bond_pnl,
+    "CDS": _cds_pnl,
+    "CR": _cds_pnl,
+    "IRSWAP": _ir_pnl,
+    "IRSWVOL": _ir_pnl,
+    "IR_LINEAR": _ir_pnl,
+}
+
+def get_pricing_function(asset: str):
+    return _PRICERS.get(asset)
+
+def aggregate_asset_pnl(df: pd.DataFrame) -> pd.DataFrame:
+    return df.groupby("asset")["pnl"].sum().reset_index().rename(columns={"pnl":"asset_pnl"})


### PR DESCRIPTION
## Summary
- compute PnL using asset‑specific pricing rules
- return asset class breakdown from pipeline

## Testing
- `python -m py_compile $(git ls-files '*.py')`