### PR TITLE
Enhance asset filtering and pnl breakdown

### DIFF
--- a/exposures.py
+++ b/exposures.py
@@ -26,8 +26,19 @@ def apply_shocks(mapped_portfolio: pd.DataFrame, rf_df: pd.DataFrame, base_curre
     return pf
 
 def asset_pnl_breakdown(pnl_df: pd.DataFrame) -> pd.DataFrame:
-    """Return total PnL per asset class."""
-    return pnl_df.groupby("asset")["pnl"].sum().reset_index().rename(columns={"pnl": "asset_pnl"})
+    """Return total PnL per asset class.
+
+    Positions without an associated risk factor will have a missing ``asset``
+    value.  We still want to include these in the output so users can clearly
+    see the impact of unmapped positions.
+    """
+    df = pnl_df.copy()
+    df["asset"] = df["asset"].fillna("UNKNOWN")
+    return (
+        df.groupby("asset")["pnl"].sum()
+        .reset_index()
+        .rename(columns={"pnl": "asset_pnl"})
+    )
 
 def total_portfolio_pnl(pnl_df: pd.DataFrame) -> float:
     """Return total portfolio PnL."""

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -1,0 +1,19 @@
+import pandas as pd
+from pipeline_flow import portfolio_assets
+from exposures import asset_pnl_breakdown
+
+def test_portfolio_assets():
+    mapped = pd.DataFrame({'rf_code':['RF1','RF2']})
+    univ = pd.DataFrame({'original':['RF1','RF2','RF3'],
+                         'asset':['EQ','BOND','FX']})
+    assets = portfolio_assets(mapped, univ)
+    assert set(assets) == {'EQ', 'BOND'}
+
+def test_asset_pnl_breakdown():
+    df = pd.DataFrame({'asset':['EQ', None], 'pnl':[10, -5]})
+    brk = asset_pnl_breakdown(df)
+    assert set(brk.asset) == {'EQ', 'UNKNOWN'}
+    eq_pnl = brk.loc[brk.asset=='EQ','asset_pnl'].iloc[0]
+    unk_pnl = brk.loc[brk.asset=='UNKNOWN','asset_pnl'].iloc[0]
+    assert eq_pnl == 10
+    assert unk_pnl == -5


### PR DESCRIPTION
## Summary
- include unmapped positions in `asset_pnl_breakdown`
- expose helper `portfolio_assets` to detect asset classes in a portfolio
- use the helper in the pipeline flows
- restrict asset selection in the Streamlit UI to portfolio assets
- add unit tests for the new helper and breakdown function

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*